### PR TITLE
setup: force utf8-encoding on systems where it's not the default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ except:
 
 
 version = ''
-with open('the_big_username_blacklist/__init__.py', 'r') as fd:
+with open('the_big_username_blacklist/__init__.py', 'r', encoding='utf-8') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
                         fd.read(), re.MULTILINE).group(1)
 


### PR DESCRIPTION
If a system's locale.getprefferedencoding(False) doesn't return utf-8, opening the __init__.py file will fail as it contains a non-ascii character.